### PR TITLE
Change package.json exports property to support typescript >4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,14 @@
   "types": "./dist/cjs/main.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/cjs/main.js",
-      "import": "./dist/esm/main.js"
+      "require": {
+        "types": "./dist/cjs/main.d.ts",
+        "default": "./dist/cjs/main.js"
+      },
+      "import": {
+        "types": "./dist/cjs/main.d.ts",
+        "default": "./dist/esm/main.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Sorry for not creating an issue first but the fix was so simple.

The problem I had was when importing the module the following TS error appeared:

```
Could not find a declaration file for module 'bankdata-germany'. '__REDACTED__/node_modules/bankdata-germany/dist/esm/main.js' implicitly has an 'any' type.
  There are types at '__REDACTED__/node_modules/bankdata-germany/dist/cjs/main.d.ts', but this result could not be resolved when respecting package.json "exports". The 'bankdata-germany' library may need to update its package.json or typings.
```

Some searching later I found out that this has to do with typescript >4.7 handling the exports property in package.json differently. See this: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing