### PR TITLE
Add bankDataByBIC function and related tests

### DIFF
--- a/src/__tests__/lib/data.spec.ts
+++ b/src/__tests__/lib/data.spec.ts
@@ -20,6 +20,7 @@ import currentBank from "../../data/current.json";
 import nextBank from "../../data/next.json";
 import {
   bankDataByBBAN,
+  bankDataByBIC,
   bankDataByBLZ,
   bankDataByIBAN,
   bankDataSet,
@@ -158,6 +159,25 @@ describe("isBICInData", () => {
   });
   it("returns false for unknown BIC AAAADE00000", () => {
     expect(isBICInData("AAAADE00000")).toEqual(false);
+  });
+});
+
+describe("bankDataByBIC", () => {
+  it("returns data for BIC", () => {
+    expect(bankDataByBIC("MARKDEF1100")).toEqual({
+      bankName: "Bundesbank",
+      bic: "MARKDEF1100",
+      blz: "10000000",
+    });
+  });
+  it("returns null for BIC null (not a string)", () => {
+    expect(bankDataByBIC(null)).toEqual(null);
+  });
+  it("returns null for invalid BIC format", () => {
+    expect(bankDataByBIC("1")).toEqual(null);
+  });
+  it("returns null for unknown BIC AAAADE00000", () => {
+    expect(bankDataByBIC("AAAADE00000")).toEqual(null);
   });
 });
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -150,6 +150,38 @@ export const bankDataByIBAN = (
 };
 
 /**
+ * Get bank data for bank with given BIC
+ *
+ * @param bic BIC to search for
+ * @param date Bank data valid at this date (default: current date)
+ * @returns Bank data or null
+ */
+export const bankDataByBIC = (
+  bic: ProbablyString,
+  date?: string | Date
+): BankData | null => {
+  if (!bic || !bic.match(/^[A-Z]{4}DE[A-Z0-9]{2}([A-Z0-9]{3})?$/i)) {
+    return null;
+  }
+
+  const searchBIC = `${bic.toUpperCase()}${bic.length === 8 ? "XXX" : ""}`;
+
+  const result = Object.entries(bankDataSet(date)).find(
+    ([, bank]) => bank[1] && bank[1] === searchBIC
+  );
+
+  if (!result) {
+    return null;
+  }
+
+  return {
+    bankName: result[1][0],
+    bic: result[1][1],
+    blz: result[0],
+  };
+};
+
+/**
  * Search all bank data and check if any contains the BIC
  *
  * @param bic BIC to search for
@@ -157,15 +189,5 @@ export const bankDataByIBAN = (
  * @returns Whether BIC exists in bank data
  */
 export const isBICInData = (bic: string, date?: string | Date): boolean => {
-  if (!bic.match(/^[A-Z]{4}DE[A-Z0-9]{2}([A-Z0-9]{3})?$/i)) {
-    return false;
-  }
-
-  const searchBIC = `${bic.toUpperCase()}${bic.length === 8 ? "XXX" : ""}`;
-
-  return (
-    typeof Object.values(bankDataSet(date)).find(
-      (bank) => bank[1] && bank[1] === searchBIC
-    ) !== "undefined"
-  );
+  return bankDataByBIC(bic, date) != null;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,13 +16,19 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { bankDataByBBAN, bankDataByBLZ, bankDataByIBAN } from "./lib/data";
+import {
+  bankDataByBBAN,
+  bankDataByBIC,
+  bankDataByBLZ,
+  bankDataByIBAN,
+} from "./lib/data";
 import { BankData, ProbablyString } from "./lib/types";
 import { isValidBIC } from "./lib/validate";
 
 export {
   BankData,
   bankDataByBBAN,
+  bankDataByBIC,
   bankDataByBLZ,
   bankDataByIBAN,
   isValidBIC,


### PR DESCRIPTION
I have a use case where I have a BIC and need to get the bank name.

For this I created a `bankDataByBIC` function which borrows a lot of logic from `isBICInData`.

I then changed `isBICInData` to use `bankDataByBic` to prevent code duplication.

Also there are tests!

Let me know if you need anything else to accept this.